### PR TITLE
Update registry keys in windows cleanup script

### DIFF
--- a/windows/cleanup.bat
+++ b/windows/cleanup.bat
@@ -48,7 +48,8 @@ PowerShell -Command "Get-AppxProvisionedPackage -Online | Where-Object DisplayNa
 ECHO Removing lame shortcut folders in Explorer...
 
 REM *** 3D Objects
-REG Delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\{31C0DD25-9439-4F12-BF41-7FF4EDA38722}" /f
+REG Delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{0DB7E03F-FC29-4DC6-9020-FF41B59E513A}" /f
+REG Delete "HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{0DB7E03F-FC29-4DC6-9020-FF41B59E513A}" /f
 
 REM *** CameraRollLibary
 REG Delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\{2B20DF75-1EDA-4039-8097-38798227D5B7}" /f

--- a/windows/cleanup.bat
+++ b/windows/cleanup.bat
@@ -76,7 +76,6 @@ REG Delete "HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\
 
 REM *** Desktop
 REG Delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}" /f
-
 REG Delete "HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\MyComputer\NameSpace\{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}" /f
 
 ECHO Disabling sticky keys...


### PR DESCRIPTION
The rest of the keys were fine. Camera Roll is an interesting case because on the one hand it doesn't appear to be an issue anymore (you can just delete it and it doesn't appear to come back) but on the other hand I wasn't sure you'd just want the script to ignore it.

Apropos, I was inspired by your script to make my own as a PowerShell script. [Take a look](https://github.com/k-obrien/windows-cleanup) if you're interested, and feedback welcome. 😀 